### PR TITLE
Add custom attribute retrieval for OpenID providers

### DIFF
--- a/pages/docs/configuration/authentication/OAuth2-OIDC/aws.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/aws.mdx
@@ -111,3 +111,34 @@ OPENID_CALLBACK_URL=/oauth/openid/callback
 7. Save the .env file
 
 > Note: If using docker, run `docker compose up -d` to apply the .env configuration changes
+
+
+### Configuring Custom Data with AWS Cognito OpenID (Optional)
+
+Enhance your AWS Cognito OpenID setup by retrieving user attributes during authentication.
+
+ 1. **Specify Custom Data Fields**
+Define additional attributes to fetch (e.g., `name`, `email`, `customAttribute`) by adding this to your `.env` file:
+```bash filename=".env"
+OPENID_CUSTOM_DATA="name,email,customAttribute"
+OPENID_PROVIDER=aws_cognito
+```
+> **Note**: To enable this feature, you must not leave `OPENID_CUSTOM_DATA` empty. Specify the attributes explicitly.
+- `OPENID_CUSTOM_DATA`: Attributes to retrieve from Cognito.
+- `OPENID_PROVIDER`: Set to `aws_cognito` for Cognito.
+
+2. **Set OpenID Admin Role**
+Include the admin role configuration in your `.env` file:
+```bash filename=".env"
+OPENID_ADMIN_ROLE=[YourAdminRole]
+```
+- `OPENID_ADMIN_ROLE`: Define the admin role for your application.
+
+ 3. **Apply Changes**
+Save the `.env` file and restart your app to apply the updates:
+```bash
+docker compose up -d
+```
+
+4. **How It Works**
+During authentication, Cognito fetches the attributes specified in `OPENID_CUSTOM_DATA` and makes them accessible within your application, enabling dynamic integration of user-specific data.

--- a/pages/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
@@ -57,3 +57,43 @@ OPENID_REQUIRED_ROLE="Your Group Name"
 
 > Note: If using docker, run `docker compose up -d` to apply the .env configuration changes
 
+
+---
+
+
+### Optional: Configuring Custom Data with Microsoft OpenID
+
+Enhance your Microsoft OpenID setup by including custom claims or advanced queries to retrieve additional user data from Microsoft OpenID or Microsoft Graph.
+
+1. **Add Custom Claims**
+Define specific claims like `jobTitle` or `department` by adding the following to your `.env` file:
+```bash filename=".env"
+OPENID_CUSTOM_DATA="jobTitle,department"
+OPENID_PROVIDER=microsoft
+```
+> **Note**: To enable this feature, you must not leave `OPENID_CUSTOM_DATA` empty. Specify the attributes explicitly.
+- `OPENID_CUSTOM_DATA`: Attributes to retrieve during authentication.
+- `OPENID_PROVIDER`: Set to `microsoft` to use Microsoft Azure Entra as the OpenID provider.
+
+2. **Use Microsoft Graph Queries** (Advanced)
+For hierarchical or nested data, configure a Microsoft Graph query in your `.env` file:
+```bash filename=".env"
+OPENID_CUSTOM_DATA="onPremisesDistinguishedName&$expand=manager($select=displayName,userPrincipalName)"
+```
+This retrieves attributes like the user's distinguished name and their manager's details.
+
+3. **Set OpenID Admin Role**
+Include the admin role configuration in your `.env` file:
+```bash filename=".env"
+OPENID_ADMIN_ROLE=admin
+```
+- `OPENID_ADMIN_ROLE`: Define the admin role for your application.
+
+4. **Apply Configuration Changes**
+Save the `.env` file and restart your app to apply the updates:
+```bash
+docker compose up -d
+```
+
+5. **How It Works**
+During authentication, Microsoft OpenID or Microsoft Graph fetches the attributes specified in `OPENID_CUSTOM_DATA`, making them accessible within your application for dynamic integration.

--- a/pages/docs/configuration/authentication/OAuth2-OIDC/keycloak.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/keycloak.mdx
@@ -66,3 +66,34 @@ If you want to restrict access to users with specific roles, you can define role
   OPENID_REQUIRED_ROLE_TOKEN_KIND=(access|id) # that means, `access` or `id`
   OPENID_REQUIRED_ROLE_PARAMETER_PATH="realm_access.roles"
   ```
+
+
+### Configuring Custom Data with Keycloak OpenID (Optional)
+
+Enhance your Keycloak OpenID setup by retrieving additional user attributes using the Admin API.
+
+#### 1. **Specify Custom Data Fields**
+Define attributes like `email`, `username`, or `customAttribute` by adding this to your `.env` file:
+   ```bash filename=".env"
+   OPENID_CUSTOM_DATA="email,username,customAttribute"
+   OPENID_PROVIDER=keycloak
+   ```
+   > **Note**: To enable this feature, you must specify attributes in `OPENID_CUSTOM_DATA`. Leaving it empty disables custom data retrieval.
+   - `OPENID_CUSTOM_DATA`: Attributes to retrieve from Keycloak.
+   - `OPENID_PROVIDER`: Specifies Keycloak as the OpenID provider.
+
+#### 2. **Set OpenID Admin Role**
+Include the admin role configuration in your `.env` file:
+   ```bash filename=".env"
+   OPENID_ADMIN_ROLE=[YourAdminRole]
+   ```
+   - `OPENID_ADMIN_ROLE`: Define the admin role for your application.
+
+#### 3. **Apply Changes**
+Save the `.env` file and restart the app to apply updates:
+   ```bash
+   docker compose up -d
+   ```
+
+#### 4. **How It Works**
+During authentication, the Keycloak Admin API fetches the attributes specified in `OPENID_CUSTOM_DATA` and makes them accessible within your application, enabling dynamic integration of user-specific data.


### PR DESCRIPTION
### Description

This pull request introduces functionality to support retrieval of custom user attributes for OpenID providers including Keycloak, AWS Cognito, and Microsoft. Users can now:

- Define desired attributes in the `.env` file.
- Configure admin roles and user-specific attributes.
- Seamlessly integrate customized user data during authentication.

Detailed provider-specific setup instructions are included.